### PR TITLE
live availability page displays info for all decks now

### DIFF
--- a/9erPark/Controller/HomePage.swift
+++ b/9erPark/Controller/HomePage.swift
@@ -7,29 +7,45 @@
 
 import UIKit
 
-class HomePage: UIViewController {
+class HomePage: UIViewController, ParkingManagerDelegate {
 
     @IBOutlet weak var findOptimalButton: UIButton!
+    var parkingInfo: Dictionary<String, ParkingDeck>?
+    var parkingManager = ParkingManager()
     
     override func viewDidLoad() {
         super.viewDidLoad()
         //edgesForExtendedLayout = []
         findOptimalButton.layer.cornerRadius = 19
+        parkingManager.delegate = self
+        parkingManager.performRequest()
+    }
+    
+    func didUpdateParking(_ parkingManager: ParkingManager, parkingDict: Dictionary<String, ParkingDeck>) {
+        DispatchQueue.main.async{
+            self.parkingInfo =  parkingDict
+        }
+    }
+    
+    func didFailWithError(error: Error) {
+        print(error)
     }
 
     @IBAction func liveParkingPressed(_ sender: Any) {
         self.performSegue(withIdentifier: "goToPercentages", sender: self)
-        
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "goToPercentages" {
             let destinationVC = segue.destination as! LiveFeedPage
-            destinationVC.deckName = "Test Deck"
-            destinationVC.width = 0.5 * 253
-            destinationVC.percent = "50% Available"
+            destinationVC.parkingDict = parkingInfo
+//            destinationVC.deckName = "Test Deck"
+//            destinationVC.width = 0.5 * 253
+//            destinationVC.percent = "50% Available"
         }
     }
+    
+    
     
 }
 

--- a/9erPark/Controller/LiveFeedPage.swift
+++ b/9erPark/Controller/LiveFeedPage.swift
@@ -10,18 +10,84 @@ import UIKit
 class LiveFeedPage : UIViewController {
     
     
-    var width : CGFloat?
-    var deckName : String?
-    var percent : String?
+//    var width : CGFloat?
+//    var deckName : String?
+//    var percent : String?
     
+    var parkingDict : Dictionary<String, ParkingDeck>?
+    var i = 1
+
     @IBOutlet weak var deck1Label: UILabel!
-    @IBOutlet weak var progressBarLabel: UIView!
-    @IBOutlet weak var percent1Label: UILabel!
-    @IBOutlet weak var progressBarWidth: NSLayoutConstraint!
+    @IBOutlet weak var deck2Label: UILabel!
+    @IBOutlet weak var deck3Label: UILabel!
+    @IBOutlet weak var deck4Label: UILabel!
+    @IBOutlet weak var deck5Label: UILabel!
+    @IBOutlet weak var deck6Label: UILabel!
+    @IBOutlet weak var deck7Label: UILabel!
+    @IBOutlet weak var deck8Label: UILabel!
+    @IBOutlet weak var deck9Label: UILabel!
+    @IBOutlet weak var deck10Label: UILabel!
+    
+    
+    @IBOutlet weak var deck1BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck2BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck3BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck4BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck5BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck6BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck7BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck8BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck9BarWidth: NSLayoutConstraint!
+    
+    @IBOutlet weak var deck10BarWidth: NSLayoutConstraint!
     
     override func viewDidLoad() {
-        deck1Label.text = deckName!
-        progressBarWidth.constant = width!
-        percent1Label.text = percent!
+        
+        for (key,value) in parkingDict! {
+            
+            switch i {
+            case 1:
+                deck1Label.text = value.name
+                deck1BarWidth.constant = CGFloat(value.percent * 253)
+            case 2:
+                deck2Label.text = value.name
+                deck2BarWidth.constant = CGFloat(value.percent * 253)
+            case 3:
+                deck3Label.text = value.name
+                deck3BarWidth.constant = CGFloat(value.percent * 253)
+            case 4:
+                deck4Label.text = value.name
+                deck4BarWidth.constant = CGFloat(value.percent * 253)
+            case 5:
+                deck5Label.text = value.name
+                deck5BarWidth.constant = CGFloat(value.percent * 253)
+            case 6:
+                deck6Label.text = value.name
+                deck6BarWidth.constant = CGFloat(value.percent * 253)
+            case 7:
+                deck7Label.text = value.name
+                deck7BarWidth.constant = CGFloat(value.percent * 253)
+            case 8:
+                deck8Label.text = value.name
+                deck8BarWidth.constant = CGFloat(value.percent * 253)
+            case 9:
+                deck9Label.text = value.name
+                deck9BarWidth.constant = CGFloat(value.percent * 253)
+            case 10:
+                deck10Label.text = value.name
+                deck10BarWidth.constant = CGFloat(value.percent * 253)
+            default:
+                print("default")
+            }
+            i+=1
+        }
     }
 }

--- a/9erPark/View/Base.lproj/Main.storyboard
+++ b/9erPark/View/Base.lproj/Main.storyboard
@@ -270,7 +270,7 @@ as parking is reserved for tonight’s game.</string>
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="140"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Building Select" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a3f-UC-ZJX">
-                                        <rect key="frame" x="16" y="90" width="228" height="40"/>
+                                        <rect key="frame" x="16" y="89" width="225.5" height="41"/>
                                         <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="34"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -335,7 +335,7 @@ as parking is reserved for tonight’s game.</string>
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="a08-Oj-5cV"/>
-                        <color key="backgroundColor" red="0.99978190659999999" green="0.99657779930000001" blue="0.96078008410000004" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="I1h-ea-5CM"/>
                 </viewController>
@@ -348,7 +348,7 @@ as parking is reserved for tonight’s game.</string>
             <objects>
                 <viewController id="xCJ-my-A1O" customClass="LiveFeedPage" customModule="_erPark" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="XaF-Hw-Uw6">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="1060"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWS-Ph-nFP">
@@ -370,66 +370,470 @@ as parking is reserved for tonight’s game.</string>
                                     <constraint firstAttribute="bottom" secondItem="DU2-o7-SYL" secondAttribute="bottom" constant="10" id="zuy-zU-ghm"/>
                                 </constraints>
                             </view>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h1U-Js-ks9" userLabel="deck1Name">
-                                <rect key="frame" x="41" y="155" width="42" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Bfc-og-cif" userLabel="bar1Bg">
-                                <rect key="frame" x="32" y="180" width="253" height="33"/>
-                                <color key="backgroundColor" red="0.76862745098039209" green="0.76862745098039209" blue="0.76862745098039209" alpha="1" colorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="33" id="BR5-Z8-uA9"/>
-                                    <constraint firstAttribute="width" constant="253" id="Ywy-lF-yeM"/>
-                                </constraints>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0K1-zP-7Ys" userLabel="progressBar1">
-                                <rect key="frame" x="32" y="180" width="150" height="33"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4l7-Pj-efr">
+                                <rect key="frame" x="0.0" y="140" width="414" height="1060"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--% Available" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kc6-NP-TvS" userLabel="percent1Label">
-                                        <rect key="frame" x="29" y="6" width="92" height="20"/>
-                                        <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
-                                        <color key="textColor" systemColor="systemBackgroundColor"/>
-                                        <nil key="highlightedColor"/>
-                                    </label>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BfR-mm-Z8r" userLabel="contentView">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1200"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ybj-tJ-rEL" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="35" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g21-Dq-gHY" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745098039209" green="0.76862745098039209" blue="0.76862745098039209" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="B95-DA-YOh"/>
+                                                            <constraint firstAttribute="width" constant="253" id="UcD-Z6-2gi"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yvy-4I-Hzw" userLabel="deck1Percent">
+                                                        <rect key="frame" x="1" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078431372548" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="4bx-Mg-b7N"/>
+                                                            <constraint firstAttribute="width" constant="150" id="wsG-K1-aAO"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="33" id="3Y5-ZH-Vrd"/>
+                                                    <constraint firstItem="Yvy-4I-Hzw" firstAttribute="leading" secondItem="Ybj-tJ-rEL" secondAttribute="leading" constant="1" id="HKU-t6-A2a"/>
+                                                    <constraint firstItem="g21-Dq-gHY" firstAttribute="leading" secondItem="Ybj-tJ-rEL" secondAttribute="leading" id="NUL-Ax-aLw"/>
+                                                    <constraint firstItem="Yvy-4I-Hzw" firstAttribute="top" secondItem="Ybj-tJ-rEL" secondAttribute="top" id="hTj-tT-e23"/>
+                                                    <constraint firstAttribute="width" constant="253" id="lJg-iS-lc9"/>
+                                                    <constraint firstItem="g21-Dq-gHY" firstAttribute="top" secondItem="Ybj-tJ-rEL" secondAttribute="top" id="zaB-xj-r22"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0oe-SR-frN" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="109" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zbE-c6-5Xh" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="QNp-Kn-1aA"/>
+                                                            <constraint firstAttribute="width" constant="253" id="aHg-rk-bcY"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1dV-wu-PMq" userLabel="deck2Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="Ds7-WL-X1Z"/>
+                                                            <constraint firstAttribute="width" constant="150" id="coU-SQ-uKW"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="1dV-wu-PMq" firstAttribute="leading" secondItem="0oe-SR-frN" secondAttribute="leading" id="7OX-yw-fzP"/>
+                                                    <constraint firstItem="1dV-wu-PMq" firstAttribute="top" secondItem="0oe-SR-frN" secondAttribute="top" id="Njo-YD-JGO"/>
+                                                    <constraint firstAttribute="height" constant="33" id="cFe-aN-Bwi"/>
+                                                    <constraint firstAttribute="width" constant="253" id="h8H-EZ-yNA"/>
+                                                    <constraint firstItem="zbE-c6-5Xh" firstAttribute="leading" secondItem="0oe-SR-frN" secondAttribute="leading" id="j3K-Fk-uGc"/>
+                                                    <constraint firstItem="zbE-c6-5Xh" firstAttribute="top" secondItem="0oe-SR-frN" secondAttribute="top" id="xwq-7l-2fP"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qfK-jO-tei" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="183" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7RA-Bu-w5C" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="KSi-Tp-dRe"/>
+                                                            <constraint firstAttribute="width" constant="253" id="a5K-s1-18W"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wBS-uj-0n0" userLabel="deck3Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="FDV-lF-MVk"/>
+                                                            <constraint firstAttribute="width" constant="150" id="le3-o3-YNC"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="wBS-uj-0n0" firstAttribute="top" secondItem="qfK-jO-tei" secondAttribute="top" id="78I-Dn-QA0"/>
+                                                    <constraint firstItem="wBS-uj-0n0" firstAttribute="leading" secondItem="qfK-jO-tei" secondAttribute="leading" id="CHj-Id-PMv"/>
+                                                    <constraint firstItem="7RA-Bu-w5C" firstAttribute="top" secondItem="qfK-jO-tei" secondAttribute="top" id="HWk-Gg-wuD"/>
+                                                    <constraint firstItem="7RA-Bu-w5C" firstAttribute="leading" secondItem="qfK-jO-tei" secondAttribute="leading" id="IUn-wn-YXj"/>
+                                                    <constraint firstAttribute="height" constant="33" id="fCv-09-Zbi"/>
+                                                    <constraint firstAttribute="width" constant="253" id="n2y-Tj-Al1"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jEQ-Re-cuS" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="257" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hGg-sM-Pfd" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="l7x-kK-nhh"/>
+                                                            <constraint firstAttribute="width" constant="253" id="rkt-nx-uv9"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Acc-EF-chk" userLabel="deck4Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="150" id="Ixp-c3-Mp9"/>
+                                                            <constraint firstAttribute="height" constant="33" id="nV3-K9-eJ3"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="253" id="1C6-Hr-mX6"/>
+                                                    <constraint firstItem="Acc-EF-chk" firstAttribute="leading" secondItem="jEQ-Re-cuS" secondAttribute="leading" id="6yK-g5-JhD"/>
+                                                    <constraint firstItem="Acc-EF-chk" firstAttribute="top" secondItem="jEQ-Re-cuS" secondAttribute="top" id="PeO-Em-sZK"/>
+                                                    <constraint firstItem="hGg-sM-Pfd" firstAttribute="top" secondItem="jEQ-Re-cuS" secondAttribute="top" id="RRD-Tg-BAh"/>
+                                                    <constraint firstAttribute="height" constant="33" id="gZd-Ju-x5A"/>
+                                                    <constraint firstItem="hGg-sM-Pfd" firstAttribute="leading" secondItem="jEQ-Re-cuS" secondAttribute="leading" id="vBK-v6-dhA"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="IKc-eK-7oy" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="331" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1cU-81-EX7" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="P1l-jX-FBt"/>
+                                                            <constraint firstAttribute="width" constant="253" id="sLj-yF-ePU"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zuB-IT-mHK" userLabel="deck5Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="4uq-3f-bg3"/>
+                                                            <constraint firstAttribute="width" constant="150" id="rmE-jQ-d9Z"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="1cU-81-EX7" firstAttribute="leading" secondItem="IKc-eK-7oy" secondAttribute="leading" id="2g3-RL-HjJ"/>
+                                                    <constraint firstAttribute="height" constant="33" id="EH9-lI-fHP"/>
+                                                    <constraint firstItem="1cU-81-EX7" firstAttribute="top" secondItem="IKc-eK-7oy" secondAttribute="top" id="P7M-5E-Bxz"/>
+                                                    <constraint firstItem="zuB-IT-mHK" firstAttribute="leading" secondItem="IKc-eK-7oy" secondAttribute="leading" id="SN5-0k-WuP"/>
+                                                    <constraint firstItem="zuB-IT-mHK" firstAttribute="top" secondItem="IKc-eK-7oy" secondAttribute="top" id="Sdg-98-ZDH"/>
+                                                    <constraint firstAttribute="width" constant="253" id="VNE-JM-Jqx"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Y03-VS-2iu" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="405" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yf0-w5-Fp6" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="8zn-gO-Nyq"/>
+                                                            <constraint firstAttribute="width" constant="253" id="UxR-hg-s4u"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v6H-jz-HxG" userLabel="deck6Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="150" id="CUY-Pq-nZb"/>
+                                                            <constraint firstAttribute="height" constant="33" id="x4E-5t-Ywe"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="v6H-jz-HxG" firstAttribute="top" secondItem="Y03-VS-2iu" secondAttribute="top" id="1P6-gu-W9f"/>
+                                                    <constraint firstAttribute="width" constant="253" id="3mr-rR-Tup"/>
+                                                    <constraint firstItem="v6H-jz-HxG" firstAttribute="leading" secondItem="Y03-VS-2iu" secondAttribute="leading" id="8Om-cJ-Txt"/>
+                                                    <constraint firstItem="Yf0-w5-Fp6" firstAttribute="leading" secondItem="Y03-VS-2iu" secondAttribute="leading" id="9b8-3V-8gc"/>
+                                                    <constraint firstItem="Yf0-w5-Fp6" firstAttribute="top" secondItem="Y03-VS-2iu" secondAttribute="top" id="f6N-q7-E8y"/>
+                                                    <constraint firstAttribute="height" constant="33" id="jHb-Df-rI2"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gQg-Kd-aqe" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="479" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yMZ-7g-WSy" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="253" id="bSa-gG-d9r"/>
+                                                            <constraint firstAttribute="height" constant="33" id="o0L-XP-0ok"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1of-uK-QTg" userLabel="deck7Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="150" id="Z17-vp-JbL"/>
+                                                            <constraint firstAttribute="height" constant="33" id="wfZ-9x-mes"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="yMZ-7g-WSy" firstAttribute="leading" secondItem="gQg-Kd-aqe" secondAttribute="leading" id="0wo-4U-2FH"/>
+                                                    <constraint firstAttribute="height" constant="33" id="4PC-1V-4dk"/>
+                                                    <constraint firstAttribute="width" constant="253" id="aMN-n4-AgN"/>
+                                                    <constraint firstItem="yMZ-7g-WSy" firstAttribute="top" secondItem="gQg-Kd-aqe" secondAttribute="top" id="cZW-7Y-VJn"/>
+                                                    <constraint firstItem="1of-uK-QTg" firstAttribute="top" secondItem="gQg-Kd-aqe" secondAttribute="top" id="n5S-pH-rgx"/>
+                                                    <constraint firstItem="1of-uK-QTg" firstAttribute="leading" secondItem="gQg-Kd-aqe" secondAttribute="leading" id="yfc-Wu-pyM"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="v80-oE-aY0" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="553" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uGS-ba-FWC" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="3ml-yf-dB7"/>
+                                                            <constraint firstAttribute="width" constant="253" id="5St-PC-stk"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yd7-dS-LxH" userLabel="deck8Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="150" id="8qi-fS-ENR"/>
+                                                            <constraint firstAttribute="height" constant="33" id="jYi-ce-KMR"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="yd7-dS-LxH" firstAttribute="top" secondItem="v80-oE-aY0" secondAttribute="top" id="BTj-ls-Oze"/>
+                                                    <constraint firstAttribute="width" constant="253" id="I4n-lR-hGg"/>
+                                                    <constraint firstItem="uGS-ba-FWC" firstAttribute="top" secondItem="v80-oE-aY0" secondAttribute="top" id="KU8-XJ-QDw"/>
+                                                    <constraint firstItem="yd7-dS-LxH" firstAttribute="leading" secondItem="v80-oE-aY0" secondAttribute="leading" id="RmU-vp-MBc"/>
+                                                    <constraint firstItem="uGS-ba-FWC" firstAttribute="leading" secondItem="v80-oE-aY0" secondAttribute="leading" id="ZRb-LJ-YXR"/>
+                                                    <constraint firstAttribute="height" constant="33" id="zsD-Hz-Bly"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5nI-hb-9r1" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="627" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yy0-yI-Ad9" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="cL0-go-KZD"/>
+                                                            <constraint firstAttribute="width" constant="253" id="zei-o8-rgp"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FO2-2e-Dqc" userLabel="deck9Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="Tdn-XA-sjR"/>
+                                                            <constraint firstAttribute="width" constant="150" id="aFz-6t-iz2"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="FO2-2e-Dqc" firstAttribute="leading" secondItem="5nI-hb-9r1" secondAttribute="leading" id="0og-CS-M6r"/>
+                                                    <constraint firstAttribute="height" constant="33" id="Bya-oR-fib"/>
+                                                    <constraint firstAttribute="width" constant="253" id="UPm-7T-Ayl"/>
+                                                    <constraint firstItem="Yy0-yI-Ad9" firstAttribute="leading" secondItem="5nI-hb-9r1" secondAttribute="leading" id="fsK-s4-dJz"/>
+                                                    <constraint firstItem="Yy0-yI-Ad9" firstAttribute="top" secondItem="5nI-hb-9r1" secondAttribute="top" id="vqx-39-LkU"/>
+                                                    <constraint firstItem="FO2-2e-Dqc" firstAttribute="top" secondItem="5nI-hb-9r1" secondAttribute="top" id="y3F-ZG-S30"/>
+                                                </constraints>
+                                            </view>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dTf-16-YHk" userLabel="progressBar">
+                                                <rect key="frame" x="32" y="701" width="253" height="33"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hub-fg-mSN" userLabel="barBg">
+                                                        <rect key="frame" x="0.0" y="0.0" width="253" height="33"/>
+                                                        <color key="backgroundColor" red="0.76862745099999996" green="0.76862745099999996" blue="0.76862745099999996" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="33" id="9y1-ro-59B"/>
+                                                            <constraint firstAttribute="width" constant="253" id="koz-h8-lQR"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wvo-u9-wBS" userLabel="deck10Percent">
+                                                        <rect key="frame" x="0.0" y="0.0" width="150" height="33"/>
+                                                        <color key="backgroundColor" red="0.0" green="0.50196078430000002" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="150" id="aGk-H3-TO6"/>
+                                                            <constraint firstAttribute="height" constant="33" id="k7a-WE-rxA"/>
+                                                        </constraints>
+                                                    </view>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="wvo-u9-wBS" firstAttribute="top" secondItem="dTf-16-YHk" secondAttribute="top" id="0p3-Fe-Pob"/>
+                                                    <constraint firstItem="Hub-fg-mSN" firstAttribute="leading" secondItem="dTf-16-YHk" secondAttribute="leading" id="Dk6-VZ-3Jk"/>
+                                                    <constraint firstItem="Hub-fg-mSN" firstAttribute="top" secondItem="dTf-16-YHk" secondAttribute="top" id="KVf-mN-A1e"/>
+                                                    <constraint firstAttribute="height" constant="33" id="VVx-ew-93c"/>
+                                                    <constraint firstAttribute="width" constant="253" id="ptC-xq-ZaS"/>
+                                                    <constraint firstItem="wvo-u9-wBS" firstAttribute="leading" secondItem="dTf-16-YHk" secondAttribute="leading" id="qq2-sK-eQt"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7JR-94-mo4" userLabel="deck1">
+                                                <rect key="frame" x="41" y="7" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cQm-zY-cye" userLabel="deck2">
+                                                <rect key="frame" x="41" y="81" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r8X-dd-sjO" userLabel="deck3">
+                                                <rect key="frame" x="41" y="155" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OiJ-cT-6GZ" userLabel="deck4">
+                                                <rect key="frame" x="41" y="229" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jdt-T0-6xI" userLabel="deck5">
+                                                <rect key="frame" x="41" y="303" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oXc-pp-QWP" userLabel="deck6">
+                                                <rect key="frame" x="41" y="377" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Sr9-tg-LX5" userLabel="deck7">
+                                                <rect key="frame" x="41" y="451" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="phf-4g-Nui" userLabel="deck8">
+                                                <rect key="frame" x="41" y="525" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eUa-no-lwX" userLabel="deck9">
+                                                <rect key="frame" x="41" y="599" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Parking Deck Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Bfb-eD-Efy" userLabel="deck10">
+                                                <rect key="frame" x="41" y="673" width="138" height="20"/>
+                                                <fontDescription key="fontDescription" name="Lato-Regular" family="Lato" pointSize="16"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                        </subviews>
+                                        <color key="backgroundColor" red="1" green="0.99607843137254903" blue="0.96470588235294119" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstItem="qfK-jO-tei" firstAttribute="top" secondItem="0oe-SR-frN" secondAttribute="bottom" constant="41" id="2za-z6-0ss"/>
+                                            <constraint firstItem="IKc-eK-7oy" firstAttribute="top" secondItem="jdt-T0-6xI" secondAttribute="bottom" constant="8" id="4a0-AV-Iwu"/>
+                                            <constraint firstItem="OiJ-cT-6GZ" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="6If-p2-lK6"/>
+                                            <constraint firstItem="jEQ-Re-cuS" firstAttribute="top" secondItem="qfK-jO-tei" secondAttribute="bottom" constant="41" id="6aQ-Av-Rky"/>
+                                            <constraint firstItem="r8X-dd-sjO" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="7Kd-na-WVQ"/>
+                                            <constraint firstItem="oXc-pp-QWP" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="AvY-gJ-21y"/>
+                                            <constraint firstItem="gQg-Kd-aqe" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="Deh-ad-8dT"/>
+                                            <constraint firstItem="5nI-hb-9r1" firstAttribute="top" secondItem="v80-oE-aY0" secondAttribute="bottom" constant="41" id="Dqc-O2-yyl"/>
+                                            <constraint firstItem="v80-oE-aY0" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="ER3-rY-c0U"/>
+                                            <constraint firstItem="v80-oE-aY0" firstAttribute="top" secondItem="phf-4g-Nui" secondAttribute="bottom" constant="8" id="Jb8-KH-GPd"/>
+                                            <constraint firstItem="jdt-T0-6xI" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="K3l-2j-q4Z"/>
+                                            <constraint firstItem="jEQ-Re-cuS" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="LRj-AA-Ov6"/>
+                                            <constraint firstItem="Ybj-tJ-rEL" firstAttribute="top" secondItem="BfR-mm-Z8r" secondAttribute="top" constant="35" id="Msr-gF-OIa"/>
+                                            <constraint firstItem="gQg-Kd-aqe" firstAttribute="top" secondItem="Sr9-tg-LX5" secondAttribute="bottom" constant="8" id="Pj5-De-St4"/>
+                                            <constraint firstItem="qfK-jO-tei" firstAttribute="top" secondItem="r8X-dd-sjO" secondAttribute="bottom" constant="8" id="Pvh-ya-4X7"/>
+                                            <constraint firstItem="7JR-94-mo4" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="Rf5-ep-fk2"/>
+                                            <constraint firstItem="IKc-eK-7oy" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="RzM-Ij-c46"/>
+                                            <constraint firstItem="eUa-no-lwX" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="SMH-dA-qmh"/>
+                                            <constraint firstItem="Y03-VS-2iu" firstAttribute="top" secondItem="oXc-pp-QWP" secondAttribute="bottom" constant="8" id="TCI-fd-Q65"/>
+                                            <constraint firstItem="5nI-hb-9r1" firstAttribute="top" secondItem="eUa-no-lwX" secondAttribute="bottom" constant="8" id="U5e-NN-J9D"/>
+                                            <constraint firstItem="0oe-SR-frN" firstAttribute="top" secondItem="cQm-zY-cye" secondAttribute="bottom" constant="8" id="VrT-o7-VdP"/>
+                                            <constraint firstItem="0oe-SR-frN" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="X44-RQ-fno"/>
+                                            <constraint firstAttribute="height" constant="1200" id="YZo-4D-vgf"/>
+                                            <constraint firstItem="IKc-eK-7oy" firstAttribute="top" secondItem="jEQ-Re-cuS" secondAttribute="bottom" constant="41" id="aj2-Vo-GHP"/>
+                                            <constraint firstItem="dTf-16-YHk" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="bQS-d9-FAh"/>
+                                            <constraint firstItem="5nI-hb-9r1" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="e9e-j9-BaY"/>
+                                            <constraint firstItem="dTf-16-YHk" firstAttribute="top" secondItem="Bfb-eD-Efy" secondAttribute="bottom" constant="8" id="eKU-N4-oC2"/>
+                                            <constraint firstItem="Y03-VS-2iu" firstAttribute="top" secondItem="IKc-eK-7oy" secondAttribute="bottom" constant="41" id="ewm-vm-yTs"/>
+                                            <constraint firstItem="Sr9-tg-LX5" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="glV-ky-jXZ"/>
+                                            <constraint firstItem="0oe-SR-frN" firstAttribute="top" secondItem="Ybj-tJ-rEL" secondAttribute="bottom" constant="41" id="jbm-ff-fs8"/>
+                                            <constraint firstItem="phf-4g-Nui" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="kkt-eP-2dP"/>
+                                            <constraint firstItem="cQm-zY-cye" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="n9k-ST-EAd"/>
+                                            <constraint firstItem="qfK-jO-tei" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="nUz-41-bkN"/>
+                                            <constraint firstItem="gQg-Kd-aqe" firstAttribute="top" secondItem="Y03-VS-2iu" secondAttribute="bottom" constant="41" id="o2N-on-ZDQ"/>
+                                            <constraint firstItem="Bfb-eD-Efy" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="41" id="qK4-h3-9D0"/>
+                                            <constraint firstItem="dTf-16-YHk" firstAttribute="top" secondItem="5nI-hb-9r1" secondAttribute="bottom" constant="41" id="rOk-Xd-wUP"/>
+                                            <constraint firstItem="jEQ-Re-cuS" firstAttribute="top" secondItem="OiJ-cT-6GZ" secondAttribute="bottom" constant="8" id="s08-iq-t89"/>
+                                            <constraint firstItem="Ybj-tJ-rEL" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="sKo-k2-a17"/>
+                                            <constraint firstItem="Ybj-tJ-rEL" firstAttribute="top" secondItem="7JR-94-mo4" secondAttribute="bottom" constant="8" id="vIJ-Vu-XAb"/>
+                                            <constraint firstItem="v80-oE-aY0" firstAttribute="top" secondItem="gQg-Kd-aqe" secondAttribute="bottom" constant="41" id="xHS-l3-HFP"/>
+                                            <constraint firstItem="Y03-VS-2iu" firstAttribute="leading" secondItem="BfR-mm-Z8r" secondAttribute="leading" constant="32" id="zk3-xh-LqM"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                                <color key="backgroundColor" red="0.0" green="0.50196078431372548" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstItem="Kc6-NP-TvS" firstAttribute="top" secondItem="0K1-zP-7Ys" secondAttribute="top" constant="6" id="1G8-Sl-5hg"/>
-                                    <constraint firstAttribute="trailing" secondItem="Kc6-NP-TvS" secondAttribute="trailing" constant="29" id="6Ql-x3-UEn"/>
-                                    <constraint firstItem="Kc6-NP-TvS" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0K1-zP-7Ys" secondAttribute="leading" constant="20" symbolic="YES" id="BxO-f3-cP9"/>
-                                    <constraint firstAttribute="width" constant="150" id="GRL-j2-D17"/>
-                                    <constraint firstAttribute="height" constant="33" id="xO4-4y-dB9"/>
+                                    <constraint firstItem="BfR-mm-Z8r" firstAttribute="centerY" secondItem="4l7-Pj-efr" secondAttribute="centerY" constant="70" id="6dl-99-LSB"/>
+                                    <constraint firstItem="BfR-mm-Z8r" firstAttribute="leading" secondItem="4l7-Pj-efr" secondAttribute="leading" id="BoO-mL-QSh"/>
+                                    <constraint firstItem="BfR-mm-Z8r" firstAttribute="centerX" secondItem="4l7-Pj-efr" secondAttribute="centerX" id="VE8-LH-N5L"/>
+                                    <constraint firstAttribute="bottom" secondItem="BfR-mm-Z8r" secondAttribute="bottom" constant="-140" id="gQn-zq-N6d"/>
+                                    <constraint firstItem="BfR-mm-Z8r" firstAttribute="top" secondItem="4l7-Pj-efr" secondAttribute="top" id="ns5-ja-Vvi"/>
+                                    <constraint firstAttribute="trailing" secondItem="BfR-mm-Z8r" secondAttribute="trailing" id="sSe-vH-b4t"/>
                                 </constraints>
-                            </view>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="Lh0-jw-cNd"/>
                         <color key="backgroundColor" red="0.99976009129999999" green="0.996632874" blue="0.95685786009999996" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                         <constraints>
-                            <constraint firstItem="Bfc-og-cif" firstAttribute="top" secondItem="h1U-Js-ks9" secondAttribute="bottom" constant="4" id="5Uq-6A-F9G"/>
-                            <constraint firstItem="h1U-Js-ks9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Lh0-jw-cNd" secondAttribute="leading" id="CF1-6i-7dD"/>
+                            <constraint firstItem="4l7-Pj-efr" firstAttribute="leading" secondItem="XaF-Hw-Uw6" secondAttribute="leading" id="J9l-MO-LJe"/>
                             <constraint firstAttribute="trailing" secondItem="RWS-Ph-nFP" secondAttribute="trailing" id="LK4-Qo-5eE"/>
-                            <constraint firstItem="0K1-zP-7Ys" firstAttribute="leading" secondItem="XaF-Hw-Uw6" secondAttribute="leading" constant="32" id="TNd-0E-f1w"/>
                             <constraint firstItem="RWS-Ph-nFP" firstAttribute="top" secondItem="XaF-Hw-Uw6" secondAttribute="top" id="c7Z-Kj-psO"/>
-                            <constraint firstItem="h1U-Js-ks9" firstAttribute="top" secondItem="RWS-Ph-nFP" secondAttribute="bottom" constant="15" id="cwv-gs-ysN"/>
-                            <constraint firstItem="Lh0-jw-cNd" firstAttribute="trailing" secondItem="h1U-Js-ks9" secondAttribute="trailing" constant="331" id="cxp-4q-5bu"/>
-                            <constraint firstItem="Bfc-og-cif" firstAttribute="leading" secondItem="XaF-Hw-Uw6" secondAttribute="leading" constant="32" id="iV4-OQ-A0p"/>
-                            <constraint firstItem="0K1-zP-7Ys" firstAttribute="top" secondItem="h1U-Js-ks9" secondAttribute="bottom" constant="4" id="p0I-Qt-bEy"/>
+                            <constraint firstItem="4l7-Pj-efr" firstAttribute="top" secondItem="RWS-Ph-nFP" secondAttribute="bottom" id="eHI-iZ-MsX"/>
+                            <constraint firstItem="4l7-Pj-efr" firstAttribute="width" secondItem="XaF-Hw-Uw6" secondAttribute="width" id="evz-bd-aLF"/>
+                            <constraint firstAttribute="trailing" secondItem="4l7-Pj-efr" secondAttribute="trailing" id="hhh-WW-WG0"/>
+                            <constraint firstItem="BfR-mm-Z8r" firstAttribute="width" secondItem="XaF-Hw-Uw6" secondAttribute="width" id="q8w-wG-TVt"/>
                             <constraint firstItem="RWS-Ph-nFP" firstAttribute="leading" secondItem="XaF-Hw-Uw6" secondAttribute="leading" id="sdB-Ai-Bb8"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="LZB-DS-OGE"/>
+                    <size key="freeformSize" width="414" height="1060"/>
                     <connections>
-                        <outlet property="deck1Label" destination="h1U-Js-ks9" id="Yhd-A9-jbk"/>
-                        <outlet property="percent1Label" destination="Kc6-NP-TvS" id="pdm-Gw-XsK"/>
-                        <outlet property="progressBarLabel" destination="0K1-zP-7Ys" id="teR-Ka-14l"/>
-                        <outlet property="progressBarWidth" destination="GRL-j2-D17" id="hac-vn-ku2"/>
+                        <outlet property="deck10BarWidth" destination="aGk-H3-TO6" id="bdd-5Z-ITI"/>
+                        <outlet property="deck10Label" destination="Bfb-eD-Efy" id="eWA-kW-ofS"/>
+                        <outlet property="deck1BarWidth" destination="wsG-K1-aAO" id="6sy-HZ-EBf"/>
+                        <outlet property="deck1Label" destination="7JR-94-mo4" id="h4A-Pg-ypU"/>
+                        <outlet property="deck2BarWidth" destination="coU-SQ-uKW" id="ZsR-Xz-kIb"/>
+                        <outlet property="deck2Label" destination="cQm-zY-cye" id="98a-7M-wtc"/>
+                        <outlet property="deck3BarWidth" destination="le3-o3-YNC" id="Asc-XQ-sev"/>
+                        <outlet property="deck3Label" destination="r8X-dd-sjO" id="AYX-yn-mta"/>
+                        <outlet property="deck4BarWidth" destination="Ixp-c3-Mp9" id="e2L-3Z-QNE"/>
+                        <outlet property="deck4Label" destination="OiJ-cT-6GZ" id="Y2X-BO-eDm"/>
+                        <outlet property="deck5BarWidth" destination="rmE-jQ-d9Z" id="dQo-B4-Rxt"/>
+                        <outlet property="deck5Label" destination="jdt-T0-6xI" id="hbe-3w-doe"/>
+                        <outlet property="deck6BarWidth" destination="CUY-Pq-nZb" id="lZ9-EY-9Pn"/>
+                        <outlet property="deck6Label" destination="oXc-pp-QWP" id="P60-UV-94h"/>
+                        <outlet property="deck7BarWidth" destination="Z17-vp-JbL" id="7dT-04-YrN"/>
+                        <outlet property="deck7Label" destination="Sr9-tg-LX5" id="gjI-RD-ORc"/>
+                        <outlet property="deck8BarWidth" destination="8qi-fS-ENR" id="FJO-lM-3aF"/>
+                        <outlet property="deck8Label" destination="phf-4g-Nui" id="3ms-WD-0X3"/>
+                        <outlet property="deck9BarWidth" destination="aFz-6t-iz2" id="9vx-x8-2uF"/>
+                        <outlet property="deck9Label" destination="eUa-no-lwX" id="WyJ-Kb-ObQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Hjx-Wz-KwZ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1991" y="903"/>
+            <point key="canvasLocation" x="2002.8985507246377" y="1003.7946428571428"/>
         </scene>
         <!--Optimal Page-->
         <scene sceneID="UgC-mI-ryA">
@@ -443,7 +847,7 @@ as parking is reserved for tonight’s game.</string>
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="140"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Building Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9vI-9U-JRe">
-                                        <rect key="frame" x="16" y="89" width="222.5" height="41"/>
+                                        <rect key="frame" x="16" y="89" width="223" height="41"/>
                                         <fontDescription key="fontDescription" name="Lato-Bold" family="Lato" pointSize="34"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
Added scroll view to live parking feed page, and 10 progress bars for the 10 parking decks that our API provides info for. Used for each loop to update each and every progress bar on the page. Scroll view not seeming to work, but all the progress bars are visible anyway. So that's good for now. 

Each of the progress bars represents how available (open) the parking decks are. The less green you see, the more full it is. If you see a completely green bar, the deck is completely empty. I'll add percentage labels to translate the bar percentage next time. 