### PR TITLE
uploading working project w/ no errors this time

### DIFF
--- a/9erPark/Controller/HomePage.swift
+++ b/9erPark/Controller/HomePage.swift
@@ -24,6 +24,10 @@ class HomePage: UIViewController, ParkingManagerDelegate {
     func didUpdateParking(_ parkingManager: ParkingManager, parkingDict: Dictionary<String, ParkingDeck>) {
         DispatchQueue.main.async{
             self.parkingInfo =  parkingDict
+//            for (key,value) in self.parkingInfo! {
+//                print(key)
+//                print(value)
+//            }
         }
     }
     


### PR DESCRIPTION
We had some last minute errors, and I ran into some today. The parkingDict variable sometimes contains a nil value, even when the website is up and the data is there online. So, when we open the live parking page, it throws an error. I tested the code and have come up with a hypothesis as to why.

Because our application is not optimized for storage and efficiency, sometimes if you don't let the application run on the home page for a few seconds and go directly into the live availability page, it will throw an error. As the data it requires has not yet been retrieved and processed into the dictionary/hashmap. 

Another reason for our previous errors was because the school switched the parking availability website's network configuration. Not allowing us to make calls to it from our server. However, it's up and running once again. At the moment everything works like it should.